### PR TITLE
add EC2 plugin

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -10,3 +10,5 @@ requires 'Types::Serialiser';
 requires 'IO::Socket::INET';
 requires 'Crypt::URandom';
 requires 'Time::HiRes';
+requires 'HTTP::Tiny';
+requires 'Module::Load';

--- a/lib/AWS/XRay/Plugin/EC2.pm
+++ b/lib/AWS/XRay/Plugin/EC2.pm
@@ -1,0 +1,39 @@
+package AWS::XRay::Plugin::EC2;
+use strict;
+use warnings;
+
+use HTTP::Tiny;
+
+use constant {
+    ID_ADDR => 'http://169.254.169.254/latest/meta-data/instance-id',
+    AZ_ADDR => 'http://169.254.169.254/latest/meta-data/placement/availability-zone',
+};
+
+our $METADATA;
+
+sub apply_plugin {
+    my ($class, $segment) = @_;
+
+    $METADATA ||= do {
+        my $ua = HTTP::Tiny->new(timeout => 1);
+
+        my $instance_id = do {
+            my $res = $ua->get(ID_ADDR);
+            $res->{success} ? $res->{content} : '';
+        };
+        my $az = do {
+            my $res = $ua->get(AZ_ADDR);
+            $res->{success} ? $res->{content} : '';
+        };
+
+        +{
+            instance_id       => $instance_id,
+            availability_zone => $az,
+        };
+    };
+
+    $segment->{origin}     = 'AWS::EC2::Instance';
+    $segment->{aws}->{ec2} = $METADATA;
+}
+
+1;

--- a/t/09_plugin.t
+++ b/t/09_plugin.t
@@ -1,0 +1,31 @@
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../";
+
+use AWS::XRay qw/ capture /;
+use Test::More;
+use t::Util qw/ reset segments /;
+
+sub myApp {
+    capture "remote1", sub {};
+}
+
+AWS::XRay->plugins('AWS::XRay::Plugin::EC2');
+AWS::XRay->add_capture("main", "myApp");
+
+myApp();
+
+my @seg = segments();
+
+my $root = pop @seg;
+
+is $root->{origin}, 'AWS::EC2::Instance';
+is_deeply $root->{aws}, {
+    ec2 => {
+        availability_zone => '',
+        instance_id       => '',
+    },
+};
+
+done_testing;


### PR DESCRIPTION
Official SDK of X-Ray has some plugins: https://docs.aws.amazon.com/en_us/xray/latest/devguide/xray-sdk-go-configuration.html#xray-sdk-go-configuration-plugins

In this pull request, I implemented EC2 plugin for AWS::XRay.
If there is no problem, I want to implement other plugin and support plugin system at Plack::Middleware::XRay.