### PR TITLE
fix wantarray in capture

### DIFF
--- a/lib/AWS/XRay.pm
+++ b/lib/AWS/XRay.pm
@@ -89,6 +89,7 @@ sub new_id {
 
 sub capture {
     my ($name, $code) = @_;
+    my $wantarray = wantarray;
 
     my $enabled;
     my $sampled = $SAMPLED;
@@ -113,11 +114,14 @@ sub capture {
 
     my @ret;
     eval {
-        if (wantarray) {
+        if ($wantarray) {
             @ret = $code->($segment);
         }
-        else {
+        elsif (defined $wantarray) {
             $ret[0] = $code->($segment);
+        }
+        else {
+            $code->($segment);
         }
     };
     my $error = $@;
@@ -140,7 +144,7 @@ sub capture {
         warn $@;
     }
     die $error if $error;
-    return wantarray ? @ret : $ret[0];
+    return $wantarray ? @ret : $ret[0];
 }
 
 sub capture_from {

--- a/t/09_wantarray.t
+++ b/t/09_wantarray.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use FindBin;
+
+use Test::More;
+use AWS::XRay qw/ capture /;
+
+capture "myApp", sub {
+    ok !defined(wantarray), 'void context';
+};
+
+my $ret = capture "myApp", sub {
+    ok defined(wantarray) && !wantarray, 'scalar context';
+};
+
+my @ret = capture "myApp", sub {
+    ok defined(wantarray) && wantarray, 'list context';
+};
+
+done_testing;


### PR DESCRIPTION
I want `capture` to call the code in same context with `context`,
but actually `capture` always call the code in the scalar context.

```
$ carton exec prove -lv t/09_wantarray.t 
t/09_wantarray.t .. 
not ok 1 - void context

#   Failed test 'void context'
#   at t/09_wantarray.t line 9.
ok 2 - scalar context
not ok 3 - list context

#   Failed test 'list context'
#   at t/09_wantarray.t line 17.
1..3
# Looks like you failed 2 tests of 3.
Dubious, test returned 2 (wstat 512, 0x200)
Failed 2/3 subtests 

Test Summary Report
-------------------
t/09_wantarray.t (Wstat: 512 Tests: 3 Failed: 2)
  Failed tests:  1, 3
  Non-zero exit status: 2
Files=1, Tests=3,  0 wallclock secs ( 0.02 usr  0.00 sys +  0.07 cusr  0.01 csys =  0.10 CPU)
Result: FAIL
```
