### PR TITLE
fix Bareword "Types::Serialiser::true" not allowed while "strict subs"

### DIFF
--- a/lib/AWS/XRay.pm
+++ b/lib/AWS/XRay.pm
@@ -8,6 +8,7 @@ use Crypt::URandom ();
 use IO::Socket::INET;
 use Module::Load;
 use Time::HiRes ();
+use Types::Serialiser;
 use AWS::XRay::Segment;
 use AWS::XRay::Buffer;
 


### PR DESCRIPTION
T/O