### PR TITLE
Create XRay control directory only if necessary

### DIFF
--- a/lib/AWS/XRay.pm
+++ b/lib/AWS/XRay.pm
@@ -214,7 +214,9 @@ sub add_capture {
 if ($ENV{LAMBDA_TASK_ROOT}) {
     # AWS::XRay is loaded in AWS Lambda worker.
     # notify the Lambda Runtime that initialization is complete.
-    mkdir '/tmp/.aws-xray' or warn "failed to make directory: $!";
+    unless (-e '/tmp/.aws-xray') {
+        mkdir '/tmp/.aws-xray' or warn "failed to make directory: $!";
+    }
     open my $fh, '>', '/tmp/.aws-xray/initialized' or warn "failed to create file: $!";
     close $fh;
     utime undef, undef, '/tmp/.aws-xray/initialized' or warn "failed to touch file: $!";


### PR DESCRIPTION
On some executions, I'm getting this error:

```
failed to make directory: File exists at /var/task/extlocal/lib/perl5/AWS/XRay.pm line 217.
```

We skip directory creation if it already exists