### PR TITLE
fix race condition of creating the directory

### DIFF
--- a/lib/AWS/XRay.pm
+++ b/lib/AWS/XRay.pm
@@ -214,8 +214,12 @@ sub add_capture {
 if ($ENV{LAMBDA_TASK_ROOT}) {
     # AWS::XRay is loaded in AWS Lambda worker.
     # notify the Lambda Runtime that initialization is complete.
-    unless (-e '/tmp/.aws-xray') {
-        mkdir '/tmp/.aws-xray' or warn "failed to make directory: $!";
+    unless (mkdir '/tmp/.aws-xray') {
+        # ignore the error if the directory is already exits or other process created it.
+        my $err = $!;
+        unless (-d '/tmp/.aws-xray') {
+            warn "failed to make directory: $err";
+        }
     }
     open my $fh, '>', '/tmp/.aws-xray/initialized' or warn "failed to create file: $!";
     close $fh;


### PR DESCRIPTION
there is a race condition between checking the directory is exists (`-e '/tmp/.aws-xray'`) and creating the directory(`mkdir '/tmp/.aws-xray'`).
another process may create the directory during this moment.

ref. http://www.tohoho-web.com/perl/file.htm#FileLock http://www.tohoho-web.com/wwwcgi8.htm