### PR TITLE
encode JSON as UTF-8 encoded string

### DIFF
--- a/lib/AWS/XRay/Segment.pm
+++ b/lib/AWS/XRay/Segment.pm
@@ -8,7 +8,7 @@ use JSON::XS    ();
 use Time::HiRes ();
 
 my $header = qq|{"format":"json","version":1}\n|;
-my $json   = JSON::XS->new;
+my $json   = JSON::XS->new->utf8;
 
 sub new {
     my $class = shift;

--- a/t/13_json_encoding.t
+++ b/t/13_json_encoding.t
@@ -1,0 +1,17 @@
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../";
+
+use AWS::XRay ();
+use Test::More;
+use Encode qw/decode_utf8/;
+
+local $AWS::XRay::ENABLED = 1;
+
+subtest "utf8" => sub {
+    my $segment = AWS::XRay::Segment->new({ name => decode_utf8("あ") });
+    ok $segment->close;
+};
+
+done_testing;


### PR DESCRIPTION
Though `decode_utf8("あ")` is a [valid name](https://github.com/fujiwara/AWS-XRay/blob/master/t/11_valid_name.t#L21), it throws error like `Wide character in syswrite at /Users/hitode909/.plenv/versions/5.30.0/lib/perl5/5.30.0/darwin-2level/IO/Handle.pm line 479.`

```
% prove -Ilib/ t/13_json_encoding.t
t/13_json_encoding.t ..     # No tests run!
t/13_json_encoding.t .. 1/?
#   Failed test 'No tests run for subtest "utf8"'
#   at t/13_json_encoding.t line 15.
Wide character in syswrite at /Users/hitode909/.plenv/versions/5.30.0/lib/perl5/5.30.0/darwin-2level/IO/Handle.pm line 479.
# Tests were run but no plan was declared and done_testing() was not seen.
# Looks like your test exited with 255 just after 1.
t/13_json_encoding.t .. Dubious, test returned 255 (wstat 65280, 0xff00)
Failed 1/1 subtests

Test Summary Report
-------------------
t/13_json_encoding.t (Wstat: 65280 Tests: 1 Failed: 1)
  Failed test:  1
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
Files=1, Tests=1,  0 wallclock secs ( 0.02 usr  0.00 sys +  0.08 cusr  0.01 csys =  0.11 CPU)
Result: FAIL
```

I changed `JSON::XS->new;` to `JSON::XS->new->utf8;`. It passes the tests.

> https://metacpan.org/pod/JSON::XS#utf8-flag-enabled
> If the utf8-flag is enabled, encode/decode will encode all characters using the corresponding UTF-8 multi-byte sequence, and will expect your input strings to be encoded as UTF-8, that is, no "character" of the input string must have any value > 255, as UTF-8 does not allow that.

```
% prove -Ilib/ t/
t/00_compile.t ......... ok
t/01_trace.t ........... ok
t/02_from.t ............ # Root=1-601a460a-a01117f8ea1755617487f2d7;Parent=c10c8ae2013a9604;Sampled=1
t/02_from.t ............ ok
t/03_miss_from.t ....... ok
t/04_sampling.t ........ ok
t/05_sampled_header.t .. # Root=1-601a460b-7c161044356619c0e4dd004c;Parent=6e27b9bcb14b0094;Sampled=1
# Root=1-601a460b-7c161044356619c0e4dd004c;Parent=fbd5c29d00d43517;Sampled=1
t/05_sampled_header.t .. ok
t/06_sampler.t ......... ok
t/07_buffer.t .......... ok
t/08_add.t ............. ok
t/09_wantarray.t ....... ok
t/10_plugin_ec2_v1.t ... ok
t/10_plugin_ec2_v2.t ... ok
t/11_valid_name.t ...... Wide character in print at /Users/hitode909/.plenv/versions/5.30.0/lib/perl5/5.30.0/Test2/Formatter/TAP.pm line 155.
t/11_valid_name.t ...... ok
t/12_croak_capture.t ... invalid segment name: my * App at t/12_croak_capture.t line 12.
t/12_croak_capture.t ... 1/?     # invalid segment name: my * App at t/12_croak_capture.t line 21.
t/12_croak_capture.t ... ok
t/13_json_encoding.t ... ok
All tests successful.
Files=15, Tests=101,  2 wallclock secs ( 0.05 usr  0.03 sys +  1.23 cusr  0.24 csys =  1.55 CPU)
Result: PASS
```