### PR TITLE
feat: add AUTO_CLOSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,18 @@ When $mode is 1 (default), segment data will be sent to xray daemon immediately 
 
 When $mode is 0, segment data are buffered in memory. You should call AWS::XRay->sock->flush() to send the buffered segment data or call AWS::XRay->sock->close() to discard the buffer.
 
+If auto flush mode is 1, it sets auto close mode to 1 as well.
+
+## auto\_close($mode)
+
+Set/Get auto close mode.
+
+When $mode is 1 (default), segment will be closed and the data will be either buffered in memory or sent to xray daemon immediately after capture() called.
+
+When $mode is 0, segment will remain open. You should call $segment->close() to close the segment, so the data can be buffered or sent. Open segments will be discarded at the end.
+
+If auto close mode is 0, it sets auto flush mode to 0 as well.
+
 ## AWS\_XRAY\_DAEMON\_ADDRESS environment variable
 
 Set the host and port of the X-Ray daemon. Default 127.0.0.1:2000

--- a/t/14_async.t
+++ b/t/14_async.t
@@ -1,0 +1,84 @@
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../";
+
+use AWS::XRay qw/ capture /;
+use t::Util qw/ reset segments /;
+use Test::More;
+use Time::HiRes qw / time sleep /;
+
+subtest "auto_close=1", sub {
+    reset();
+    AWS::XRay->auto_close(1);
+
+    my $seg;
+    capture "myApp", sub {
+      $seg = shift;
+      sleep 0.1;
+    };
+
+    # the segment is closed and flushed immediately
+    ok $seg->{end_time} > 0;
+    my @segments = segments();
+    ok @segments == 1;
+    ok $segments[0]->{end_time} > 0;
+};
+
+subtest "auto_close=0", sub {
+    reset();
+
+    # It implies auto_flush=0
+    AWS::XRay->auto_close(0);
+
+    my $seg;
+    capture "myApp", sub {
+      $seg = shift;
+      sleep 0.1;
+    };
+
+    # The segment is not closed and not flushed yet
+    is $seg->{end_time}, undef;
+    my @segments = segments();
+    ok @segments == 0;
+
+    # Manually close the segment
+    is $seg->{end_time}, undef;
+    $seg->close();
+    isnt $seg->{end_time}, undef;
+    @segments = segments();
+    ok @segments == 1;
+    ok time - $segments[0]->{end_time} < 0.1;
+
+    sleep 0.1;
+
+    # Manually flush the buffer
+    AWS::XRay->sock->flush();
+    @segments = segments();
+    ok @segments == 1;
+    ok time - $segments[0]->{end_time} > 0.1;
+};
+
+subtest "auto_close=0 without closing the segment", sub {
+    reset();
+
+    # It implies auto_flush=0
+    AWS::XRay->auto_close(0);
+
+    my $seg;
+    capture "myApp", sub {
+      $seg = shift;
+      sleep 0.1;
+    };
+
+    # The segment is not closed and not flushed yet
+    is $seg->{end_time}, undef;
+    my @segments = segments();
+    ok @segments == 0;
+
+    # Manually flush the buffer and discard the segment
+    AWS::XRay->sock->flush();
+    @segments = segments();
+    ok @segments == 0;
+};
+done_testing;


### PR DESCRIPTION
Currently at the end of `capture` it closes the `segment` automatically, and it either buffers the data or sends it to server immediately. It doesn't work with [Asynchronous event-driven programming](https://metacpan.org/pod/IO::Async).

We can add `AUTO_CLOSE` with default value `1` and getter/setter `auto_close($mode)` to change its behavior. If we set `auto_close(0)` which implies `auto_flush(0)` also, we can close the segment in the callback function when the task is completed, and flush the buffer at the end.

The default behavior remains the same. Test case provided to make sure it works as expected.

The following screenshot is from locally patched code running on AWS Lambda with AWS XRay in production.

![截圖 2024-08-25 09 05 39](https://github.com/user-attachments/assets/8c4e4de4-87f1-48d4-8f59-18551d5a41b2)
